### PR TITLE
AWS index: support multiple matching versions.

### DIFF
--- a/go-index/aws.go
+++ b/go-index/aws.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"time"
 
 	semver "github.com/hashicorp/go-version"
 )
@@ -82,6 +84,8 @@ func (a AWS) Match(version string) (string, error) {
 		return "", err
 	}
 
+	var imagesFromIndex []AWSImage
+
 	for _, image := range images {
 		for _, tag := range image.Tags {
 			if tag.Key == awsCoreReleaseTag {
@@ -90,13 +94,24 @@ func (a AWS) Match(version string) (string, error) {
 					return "", err
 				}
 				if release.Equal(orig) {
-					return image.ImageID, nil
+					imagesFromIndex = append(imagesFromIndex, image)
 				}
 			}
 		}
 	}
 
-	return "", ErrNoMatchingImage
+	if len(imagesFromIndex) == 0 {
+		return "", ErrNoMatchingImage
+	}
+
+	sort.Slice(imagesFromIndex[:], func(i, j int) bool {
+		current, _ := time.Parse("2015-10-21T14:39:24.000Z", imagesFromIndex[i].CreationDate)
+		next, _ := time.Parse("2015-10-21T14:39:24.000Z", imagesFromIndex[j].CreationDate)
+		return current.Unix() < next.Unix()
+	})
+
+	// return the AMI ID from the last image on the sorted list
+	return imagesFromIndex[len(imagesFromIndex)-1].ImageID, nil
 }
 
 func NewAWS() (*AWS, error) {

--- a/go-index/aws.go
+++ b/go-index/aws.go
@@ -16,9 +16,10 @@ const (
 
 type (
 	AWSImage struct {
-		ImageID string `json:"ImageId"`
-		Name    string `json:"Name"`
-		Tags    []struct {
+		CreationDate string `json:"CreationDate"`
+		ImageID      string `json:"ImageId"`
+		Name         string `json:"Name"`
+		Tags         []struct {
 			Key   string `json:"Key"`
 			Value string `json:"Value"`
 		} `json:"Tags"`

--- a/go-index/aws.go
+++ b/go-index/aws.go
@@ -104,9 +104,9 @@ func (a AWS) Match(version string) (string, error) {
 		return "", ErrNoMatchingImage
 	}
 
-	sort.Slice(imagesFromIndex[:], func(i, j int) bool {
-		current, _ := time.Parse("2015-10-21T14:39:24.000Z", imagesFromIndex[i].CreationDate)
-		next, _ := time.Parse("2015-10-21T14:39:24.000Z", imagesFromIndex[j].CreationDate)
+	sort.Slice(imagesFromIndex, func(i, j int) bool {
+		current, _ := time.Parse(time.RFC3339, imagesFromIndex[i].CreationDate)
+		next, _ := time.Parse(time.RFC3339, imagesFromIndex[j].CreationDate)
 		return current.Unix() < next.Unix()
 	})
 

--- a/go-index/aws_test.go
+++ b/go-index/aws_test.go
@@ -5,6 +5,7 @@ import (
 	_ "errors"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestAWS_Match(t *testing.T) {
@@ -40,6 +41,47 @@ func TestAWS_Match(t *testing.T) {
 			},
 			version:    "v0.2.6",
 			wantedName: "test",
+		},
+		{
+			name: "valid with multiple matching, get last one",
+			aws: AWS{
+				Fetcher: &AWSIndexFetchMock{
+					GetImagesFunc: func() (AWSImages, error) {
+						return AWSImages{
+							AWSImage{
+								CreationDate: time.Now().String(),
+								ImageID:      "first",
+								Name:         "first",
+								Tags: []struct {
+									Key   string `json:"Key"`
+									Value string `json:"Value"`
+								}{
+									{
+										Key:   awsCoreReleaseTag,
+										Value: "0.2.6",
+									},
+								},
+							},
+							AWSImage{
+								CreationDate: time.Now().Add(time.Minute).String(),
+								ImageID:      "last-image",
+								Name:         "last-image",
+								Tags: []struct {
+									Key   string `json:"Key"`
+									Value string `json:"Value"`
+								}{
+									{
+										Key:   awsCoreReleaseTag,
+										Value: "0.2.6",
+									},
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			version:    "v0.2.6",
+			wantedName: "last-image",
 		},
 		{
 			name: "not found in index",


### PR DESCRIPTION
- Support getting the latest image by sorting by CreationDate of the image.
- Add tests to cover the case.