### PR TITLE
vm: index updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+*.tags
+aws-region*.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 *.tags
 aws-region*.json
+gha-creds-*.json

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Calyptia Core - Public image indexes
 
-This is a public repository to an updated set of indexes
-of container tags and public cloud provider images.
+This is a public repository to an updated set of indexes of container tags and public cloud provider images.
 
 The following index files of supported images for [Calyptia Core](https://calyptia.com/products/calyptia-core/).
 
 | Index file                                          | Description                                                        |
 |-----------------------------------------------------|--------------------------------------------------------------------|
-| [Container images index](./container.index.json)     | List of tags available on the container registry for calyptia Core |                                                                                                              | ✔                                               |
-| [Cloud images index]()                                 | TBD                                                                |                                                                                                            | ✔                                               |
+| [Container images index](./container.index.json) | List of tags available on the container registry for Calyptia Core. |
+| [AWS VM images index](./aws.index.json)  | List of AWS VM images available. |
+| [GCP VM images index](./gcp.index.json)  | List of GCP VM images available. |
+| [Packer VM manifest](./packer-manifest.json) | The manifest from the latest Packer build. |

--- a/aws.index.json
+++ b/aws.index.json
@@ -1,182 +1,497 @@
 [
-    {
-        "CreationDate": "2022-07-18T13:02:50.000Z",
-        "ImageId": "ami-081851696915543b1",
-        "Name": "gold-calyptia-core-20220718125959",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-18T14:28:15.000Z",
-        "ImageId": "ami-01961b36be87f6363",
-        "Name": "gold-calyptia-core-20220718142548",
-        "Tags": [
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            },
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-19T13:02:30.000Z",
-        "ImageId": "ami-0c319ceecdb3369e8",
-        "Name": "gold-calyptia-core-20220719130002",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-20T12:16:31.000Z",
-        "ImageId": "ami-0fc0cac6adcc76fc6",
-        "Name": "gold-calyptia-core-20220720121428",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-20T13:30:05.000Z",
-        "ImageId": "ami-08e69fa8a013312ce",
-        "Name": "gold-calyptia-core-20220720132802",
-        "Tags": [
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            },
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-21T09:52:54.000Z",
-        "ImageId": "ami-020c731c6faa7ddc1",
-        "Name": "pr-18-calyptia-core",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-21T10:18:52.000Z",
-        "ImageId": "ami-0523f9899909023db",
-        "Name": "gold-calyptia-core-20220721101656",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-21T10:57:44.000Z",
-        "ImageId": "ami-0f2e4b00bf605d799",
-        "Name": "gold-calyptia-core-20220721105548",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-21T11:26:16.000Z",
-        "ImageId": "ami-07d4bf6ce05ec95d3",
-        "Name": "gold-calyptia-core-20220721112427",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-21T12:42:59.000Z",
-        "ImageId": "ami-0c37149c7d9a7e75d",
-        "Name": "gold-calyptia-core-20220721124106",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.6"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-22T18:16:12.000Z",
-        "ImageId": "ami-00264c37961d8215f",
-        "Name": "pr-21-calyptia-core",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.8"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    },
-    {
-        "CreationDate": "2022-07-22T18:39:11.000Z",
-        "ImageId": "ami-0dd0fb6d81d9740de",
-        "Name": "gold-calyptia-core-20220722183716",
-        "Tags": [
-            {
-                "Key": "calyptia-core-release",
-                "Value": "0.2.8"
-            },
-            {
-                "Key": "source-image",
-                "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-            }
-        ]
-    }
+  {
+    "CreationDate": "2022-07-21T12:44:32.000Z",
+    "ImageId": "ami-0dc1bf0d3665144e1",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-northeast-1",
+    "release": "0.2.6"
+  },
+  {
+    "region": "ap-northeast-1",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:58.000Z",
+    "ImageId": "ami-0da4e478b1ecc1b1f",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      },
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      }
+    ],
+    "region": "ap-northeast-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:58.000Z",
+    "ImageId": "ami-0da4e478b1ecc1b1f",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      },
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      }
+    ],
+    "region": "ap-northeast-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:44:32.000Z",
+    "ImageId": "ami-086af18cfe9eb01cc",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      },
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      }
+    ],
+    "region": "ap-northeast-2",
+    "release": "0.2.6"
+  },
+  {
+    "region": "ap-northeast-2",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:58.000Z",
+    "ImageId": "ami-084e2aa9f4a9448e7",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-northeast-2",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:58.000Z",
+    "ImageId": "ami-084e2aa9f4a9448e7",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-northeast-2",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:44:32.000Z",
+    "ImageId": "ami-00ef15bf88fc35ef9",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      },
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      }
+    ],
+    "region": "ap-south-1",
+    "release": "0.2.6"
+  },
+  {
+    "region": "ap-south-1",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:59.000Z",
+    "ImageId": "ami-0acc388431def5a47",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-south-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:59.000Z",
+    "ImageId": "ami-0acc388431def5a47",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-south-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:44:32.000Z",
+    "ImageId": "ami-0143777da7dda9621",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-southeast-1",
+    "release": "0.2.6"
+  },
+  {
+    "region": "ap-southeast-1",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:59.000Z",
+    "ImageId": "ami-0d09a3bdab15f0a44",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-southeast-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:59.000Z",
+    "ImageId": "ami-0d09a3bdab15f0a44",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-southeast-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:44:32.000Z",
+    "ImageId": "ami-0279161ed274fb37c",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      },
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      }
+    ],
+    "region": "ap-southeast-2",
+    "release": "0.2.6"
+  },
+  {
+    "region": "ap-southeast-2",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:58.000Z",
+    "ImageId": "ami-03e27eee97259aa6c",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-southeast-2",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:58.000Z",
+    "ImageId": "ami-03e27eee97259aa6c",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "ap-southeast-2",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:42:59.000Z",
+    "ImageId": "ami-0c37149c7d9a7e75d",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-east-1",
+    "release": "0.2.6"
+  },
+  {
+    "region": "us-east-1",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:48:24.000Z",
+    "ImageId": "ami-0b6ad08bd797a2aa2",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-east-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:48:24.000Z",
+    "ImageId": "ami-0b6ad08bd797a2aa2",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-east-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:44:31.000Z",
+    "ImageId": "ami-08d89c3ab007fb64b",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      },
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      }
+    ],
+    "region": "us-east-2",
+    "release": "0.2.6"
+  },
+  {
+    "region": "us-east-2",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:57.000Z",
+    "ImageId": "ami-0886c053f71e7f017",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-east-2",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:57.000Z",
+    "ImageId": "ami-0886c053f71e7f017",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-east-2",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:44:31.000Z",
+    "ImageId": "ami-0a3d96c7a7c8de419",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-west-1",
+    "release": "0.2.6"
+  },
+  {
+    "region": "us-west-1",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:57.000Z",
+    "ImageId": "ami-088d612620b3a21e0",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-west-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:57.000Z",
+    "ImageId": "ami-088d612620b3a21e0",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-west-1",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-21T12:44:31.000Z",
+    "ImageId": "ami-072350324a8f83a68",
+    "Name": "gold-calyptia-core-20220721124106",
+    "Tags": [
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      },
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.6"
+      }
+    ],
+    "region": "us-west-2",
+    "release": "0.2.6"
+  },
+  {
+    "region": "us-west-2",
+    "release": "0.2.7"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:57.000Z",
+    "ImageId": "ami-07bbda1f1784cf9a7",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-west-2",
+    "release": "0.2.8"
+  },
+  {
+    "CreationDate": "2022-07-26T13:49:57.000Z",
+    "ImageId": "ami-07bbda1f1784cf9a7",
+    "Name": "gold-calyptia-core-20220726134630",
+    "Tags": [
+      {
+        "Key": "calyptia-core-release",
+        "Value": "0.2.8"
+      },
+      {
+        "Key": "source-image",
+        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
+      }
+    ],
+    "region": "us-west-2",
+    "release": "0.2.8"
+  }
 ]

--- a/aws.index.json
+++ b/aws.index.json
@@ -38,23 +38,6 @@
     "release": "0.2.8"
   },
   {
-    "CreationDate": "2022-07-26T13:49:58.000Z",
-    "ImageId": "ami-0da4e478b1ecc1b1f",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      },
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      }
-    ],
-    "region": "ap-northeast-1",
-    "release": "0.2.8"
-  },
-  {
     "CreationDate": "2022-07-21T12:44:32.000Z",
     "ImageId": "ami-086af18cfe9eb01cc",
     "Name": "gold-calyptia-core-20220721124106",
@@ -74,23 +57,6 @@
   {
     "region": "ap-northeast-2",
     "release": "0.2.7"
-  },
-  {
-    "CreationDate": "2022-07-26T13:49:58.000Z",
-    "ImageId": "ami-084e2aa9f4a9448e7",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "ap-northeast-2",
-    "release": "0.2.8"
   },
   {
     "CreationDate": "2022-07-26T13:49:58.000Z",
@@ -148,23 +114,6 @@
     "release": "0.2.8"
   },
   {
-    "CreationDate": "2022-07-26T13:49:59.000Z",
-    "ImageId": "ami-0acc388431def5a47",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "ap-south-1",
-    "release": "0.2.8"
-  },
-  {
     "CreationDate": "2022-07-21T12:44:32.000Z",
     "ImageId": "ami-0143777da7dda9621",
     "Name": "gold-calyptia-core-20220721124106",
@@ -184,23 +133,6 @@
   {
     "region": "ap-southeast-1",
     "release": "0.2.7"
-  },
-  {
-    "CreationDate": "2022-07-26T13:49:59.000Z",
-    "ImageId": "ami-0d09a3bdab15f0a44",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "ap-southeast-1",
-    "release": "0.2.8"
   },
   {
     "CreationDate": "2022-07-26T13:49:59.000Z",
@@ -258,23 +190,6 @@
     "release": "0.2.8"
   },
   {
-    "CreationDate": "2022-07-26T13:49:58.000Z",
-    "ImageId": "ami-03e27eee97259aa6c",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "ap-southeast-2",
-    "release": "0.2.8"
-  },
-  {
     "CreationDate": "2022-07-21T12:42:59.000Z",
     "ImageId": "ami-0c37149c7d9a7e75d",
     "Name": "gold-calyptia-core-20220721124106",
@@ -294,23 +209,6 @@
   {
     "region": "us-east-1",
     "release": "0.2.7"
-  },
-  {
-    "CreationDate": "2022-07-26T13:48:24.000Z",
-    "ImageId": "ami-0b6ad08bd797a2aa2",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "us-east-1",
-    "release": "0.2.8"
   },
   {
     "CreationDate": "2022-07-26T13:48:24.000Z",
@@ -368,23 +266,6 @@
     "release": "0.2.8"
   },
   {
-    "CreationDate": "2022-07-26T13:49:57.000Z",
-    "ImageId": "ami-0886c053f71e7f017",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "us-east-2",
-    "release": "0.2.8"
-  },
-  {
     "CreationDate": "2022-07-21T12:44:31.000Z",
     "ImageId": "ami-0a3d96c7a7c8de419",
     "Name": "gold-calyptia-core-20220721124106",
@@ -423,23 +304,6 @@
     "release": "0.2.8"
   },
   {
-    "CreationDate": "2022-07-26T13:49:57.000Z",
-    "ImageId": "ami-088d612620b3a21e0",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "us-west-1",
-    "release": "0.2.8"
-  },
-  {
     "CreationDate": "2022-07-21T12:44:31.000Z",
     "ImageId": "ami-072350324a8f83a68",
     "Name": "gold-calyptia-core-20220721124106",
@@ -459,23 +323,6 @@
   {
     "region": "us-west-2",
     "release": "0.2.7"
-  },
-  {
-    "CreationDate": "2022-07-26T13:49:57.000Z",
-    "ImageId": "ami-07bbda1f1784cf9a7",
-    "Name": "gold-calyptia-core-20220726134630",
-    "Tags": [
-      {
-        "Key": "calyptia-core-release",
-        "Value": "0.2.8"
-      },
-      {
-        "Key": "source-image",
-        "Value": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220706"
-      }
-    ],
-    "region": "us-west-2",
-    "release": "0.2.8"
   },
   {
     "CreationDate": "2022-07-26T13:49:57.000Z",

--- a/gcp.index.json
+++ b/gcp.index.json
@@ -1,5 +1,37 @@
 [
   {
+    "creationTimestamp": "2022-07-26T06:48:43.376-07:00",
+    "labels": {
+      "calyptia-core-release": "0-2-8",
+      "source-image": "ubuntu-2004-lts"
+    },
+    "name": "gold-calyptia-core-20220726134630"
+  },
+  {
+    "creationTimestamp": "2022-07-26T05:50:33.371-07:00",
+    "labels": {
+      "calyptia-core-release": "0-2-8",
+      "source-image": "ubuntu-2004-lts"
+    },
+    "name": "pr-23-calyptia-core"
+  },
+  {
+    "creationTimestamp": "2022-07-26T05:21:24.302-07:00",
+    "labels": {
+      "calyptia-core-release": "0-2-8",
+      "source-image": "ubuntu-2004-lts"
+    },
+    "name": "gold-calyptia-core-20220726121926"
+  },
+  {
+    "creationTimestamp": "2022-07-26T04:17:50.180-07:00",
+    "labels": {
+      "calyptia-core-release": "0-2-8",
+      "source-image": "ubuntu-2004-lts"
+    },
+    "name": "pr-22-calyptia-core"
+  },
+  {
     "creationTimestamp": "2022-07-22T11:39:18.791-07:00",
     "labels": {
       "calyptia-core-release": "0-2-8",

--- a/gcp.index.json
+++ b/gcp.index.json
@@ -1,53 +1,5 @@
 [
   {
-    "creationTimestamp": "2022-07-26T06:48:43.376-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-8",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220726134630"
-  },
-  {
-    "creationTimestamp": "2022-07-26T05:50:33.371-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-8",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "pr-23-calyptia-core"
-  },
-  {
-    "creationTimestamp": "2022-07-26T05:21:24.302-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-8",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220726121926"
-  },
-  {
-    "creationTimestamp": "2022-07-26T04:17:50.180-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-8",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "pr-22-calyptia-core"
-  },
-  {
-    "creationTimestamp": "2022-07-22T11:39:18.791-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-8",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220722183716"
-  },
-  {
-    "creationTimestamp": "2022-07-22T11:16:19.096-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-8",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "pr-21-calyptia-core"
-  },
-  {
     "creationTimestamp": "2022-07-21T05:43:12.331-07:00",
     "labels": {
       "calyptia-core-release": "0-2-6",
@@ -56,83 +8,11 @@
     "name": "gold-calyptia-core-20220721124106"
   },
   {
-    "creationTimestamp": "2022-07-21T04:26:30.610-07:00",
+    "creationTimestamp": "2022-07-26T06:48:43.376-07:00",
     "labels": {
-      "calyptia-core-release": "0-2-6",
+      "calyptia-core-release": "0-2-8",
       "source-image": "ubuntu-2004-lts"
     },
-    "name": "gold-calyptia-core-20220721112427"
-  },
-  {
-    "creationTimestamp": "2022-07-21T03:57:21.622-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220721105548"
-  },
-  {
-    "creationTimestamp": "2022-07-21T03:19:01.637-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220721101656"
-  },
-  {
-    "creationTimestamp": "2022-07-21T02:52:38.124-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "pr-18-calyptia-core"
-  },
-  {
-    "creationTimestamp": "2022-07-20T06:30:10.047-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220720132802"
-  },
-  {
-    "creationTimestamp": "2022-07-20T05:16:46.455-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220720121428"
-  },
-  {
-    "creationTimestamp": "2022-07-19T06:02:44.472-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220719130002"
-  },
-  {
-    "creationTimestamp": "2022-07-18T07:28:23.771-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220718142548"
-  },
-  {
-    "creationTimestamp": "2022-07-18T06:02:36.463-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220718125959"
-  },
-  {
-    "creationTimestamp": "2022-07-18T04:19:49.292-07:00",
-    "labels": {
-      "calyptia-core-release": "0-2-6",
-      "source-image": "ubuntu-2004-lts"
-    },
-    "name": "gold-calyptia-core-20220718111717"
+    "name": "gold-calyptia-core-20220726134630"
   }
 ]

--- a/scripts/create-container-index.sh
+++ b/scripts/create-container-index.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -u
+
+GITHUB_TOKEN=${GITHUB_TOKEN:?}
+CONTAINER_PACKAGE=${CONTAINER_PACKAGE:-calyptia/core}
+CONTAINER_INDEX_FILE=${CONTAINER_INDEX_FILE:-container.index.json}
+
+GHCR_TOKEN=$(echo "$GITHUB_TOKEN" | base64)
+
+curl --silent -H "Authorization: Bearer $GHCR_TOKEN" https://ghcr.io/v2/"${CONTAINER_PACKAGE}"/tags/list | \
+    jq -r '.tags | map(select(.| test("^v(.*)")))' | tee "$CONTAINER_INDEX_FILE"

--- a/scripts/create-image-indexes.sh
+++ b/scripts/create-image-indexes.sh
@@ -13,7 +13,7 @@ if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
     "$SCRIPT_DIR/create-vm-aws-index.sh"
 fi
 
-if [[ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
-    echo "Detected GOOGLE_APPLICATION_CREDENTIALS so running GCP VM index generation"
+if ! gcloud config get-value account | grep -q unset ; then
+    echo "Detected gcloud authentication so running GCP VM index generation"
     "$SCRIPT_DIR/create-vm-gcp-index.sh"
 fi

--- a/scripts/create-image-indexes.sh
+++ b/scripts/create-image-indexes.sh
@@ -18,9 +18,27 @@ GHCR_TOKEN=$(echo "$GITHUB_TOKEN" | base64)
 curl --silent -H "Authorization: Bearer $GHCR_TOKEN" https://ghcr.io/v2/"${CONTAINER_PACKAGE}"/tags/list | \
     jq -r '.tags | map(select(.| test("^v(.*)")))' | tee "$CONTAINER_INDEX_FILE"
 
-# For the query make sure to match the current
-aws ec2 describe-images --owners self --filters "Name=tag-key,Values=$IMAGE_KEY" \
-    --query 'Images[] | sort_by(@, &CreationDate)[].{CreationDate: CreationDate, ImageId: ImageId, Name: Name, Tags: Tags}' --output=json | tee "$AWS_INDEX_FILE"
+# For AWS we have to iterate over regions
+for aws_region in $(aws ec2 describe-regions --output text | cut -f4)
+do
+    # As we only want a single image per tag value we need to first get our tag values then query for each one and take the latest
+    aws ec2 describe-tags --no-paginate --region "$aws_region" \
+        --filter "Name=key,Values=calyptia-core-release" --query 'Tags[*]' --output json | jq -cr 'unique_by(.Key,.Value)|.[].Value' > "$aws_region".tags
+
+    while IFS= read -r release_tag_value; do
+        # Get our images with this tag value and region, sort by creation date and select last for most recent then add region + release info
+        aws ec2 describe-images --no-paginate --owners self --region "$aws_region" \
+            --filters "Name=tag:$IMAGE_KEY,Values=$release_tag_value" "Name=name,Values=gold-calyptia-core*" \
+            --query 'Images[] | sort_by(@, &CreationDate)[].{CreationDate: CreationDate, ImageId: ImageId, Name: Name, Tags: Tags}|[-1]' \
+            --output=json | jq ". += {\"region\" : \"$aws_region\", \"release\": \"$release_tag_value\" }" > aws-region-"$aws_region"-"$release_tag_value".json
+    done <"$aws_region".tags
+    rm -f "$aws_region".tags
+
+done
+
+# Now combine our region files into a single array
+jq -s . aws-region-*.json | tee "$AWS_INDEX_FILE"
+rm -f aws-region-*.json
 
 # Sort by most recent any images with an appropriate label specified
 gcloud compute images list --no-standard-images --sort-by='~creationTimestamp' \

--- a/scripts/create-vm-aws-index.sh
+++ b/scripts/create-vm-aws-index.sh
@@ -1,0 +1,31 @@
+
+#!/bin/bash
+set -u
+
+IMAGE_KEY=${IMAGE_KEY:-calyptia-core-release}
+AWS_INDEX_FILE=${AWS_INDEX_FILE:-aws.index.json}
+
+# Assumption for GCP is authentication is complete prior to this script
+AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?}
+AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?}
+
+# For AWS we have to iterate over regions
+for aws_region in $(aws ec2 describe-regions --output text | cut -f4)
+do
+    # As we only want a single image per tag value we need to first get our tag values then query for each one and take the latest
+    aws ec2 describe-tags --no-paginate --region "$aws_region" \
+        --filter "Name=key,Values=calyptia-core-release" --query 'Tags[*]' --output json | jq -cr 'unique_by(.Key,.Value)|.[].Value' > "$aws_region".tags
+
+    # Get our images with this tag value and region, sort by creation date and select last for most recent then add region + release info
+    while IFS= read -r release_tag_value; do
+        aws ec2 describe-images --no-paginate --owners self --region "$aws_region" \
+            --filters "Name=tag:$IMAGE_KEY,Values=$release_tag_value" "Name=name,Values=gold-calyptia-core*" \
+            --query 'Images[] | sort_by(@, &CreationDate)[].{CreationDate: CreationDate, ImageId: ImageId, Name: Name, Tags: Tags}|[-1]' \
+            --output=json | jq ". += {\"region\" : \"$aws_region\", \"release\": \"$release_tag_value\" }" > aws-region-"$aws_region"-"$release_tag_value".json
+    done <"$aws_region".tags
+    rm -f "$aws_region".tags
+done
+
+# Now combine our region files into a single array
+jq -s . aws-region-*.json | tee "$AWS_INDEX_FILE"
+rm -f aws-region-*.json

--- a/scripts/create-vm-aws-index.sh
+++ b/scripts/create-vm-aws-index.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 set -u
 

--- a/scripts/create-vm-aws-index.sh
+++ b/scripts/create-vm-aws-index.sh
@@ -17,6 +17,7 @@ do
 
     # Get our images with this tag value and region, sort by creation date and select last for most recent then add region + release info
     while IFS= read -r release_tag_value; do
+        echo "Finding AMIs in region $aws_region for release $release_tag_value"
         aws ec2 describe-images --no-paginate --owners self --region "$aws_region" \
             --filters "Name=tag:$IMAGE_KEY,Values=$release_tag_value" "Name=name,Values=gold-calyptia-core*" \
             --query 'Images[] | sort_by(@, &CreationDate)[].{CreationDate: CreationDate, ImageId: ImageId, Name: Name, Tags: Tags}|[-1]' \

--- a/scripts/create-vm-gcp-index.sh
+++ b/scripts/create-vm-gcp-index.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 set -u
 

--- a/scripts/create-vm-gcp-index.sh
+++ b/scripts/create-vm-gcp-index.sh
@@ -1,0 +1,20 @@
+
+#!/bin/bash
+set -u
+
+GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:?}
+
+IMAGE_KEY=${IMAGE_KEY:-calyptia-core-release}
+GCP_INDEX_FILE=${GCP_INDEX_FILE:-gcp.index.json}
+
+# Try to keep any auth as private as possible
+# https://serverfault.com/a/849910
+CLOUDSDK_CONFIG=$(mktemp -d)
+
+gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+
+# Sort by most recent any images with an appropriate label specified
+gcloud compute images list --no-standard-images --sort-by='~creationTimestamp' \
+    --filter="labels.$IMAGE_KEY ~ .+" --format='json(name,labels)' | tee "$GCP_INDEX_FILE"
+
+rm -rf "$CLOUDSDK_CONFIG"


### PR DESCRIPTION
Resolves #12 plus a few other issues.

- Filter VM images by core release to only provide latest for a particular release.
- Provide all regions for AWS AMIs.
- Split up scripts to reduce credentials and any possible race conditions for overwriting files.