### PR TITLE
Use shared CI secret instead of repo-specific secret [sc-148705]

### DIFF
--- a/.github/workflows/update-core-fb-schemas.yaml
+++ b/.github/workflows/update-core-fb-schemas.yaml
@@ -6,4 +6,4 @@
         update-image-indexes:
             uses: ./.github/workflows/call-update-core-fluent-bit-schemas.yaml
             secrets:
-                token: ${{ secrets.CI_PAT }}
+                token: ${{ secrets.CALYPTIA_CI_PAT }}

--- a/.github/workflows/update-frontend-schemas.yaml
+++ b/.github/workflows/update-frontend-schemas.yaml
@@ -17,7 +17,7 @@ jobs:
           - name: Repository Dispatch
             uses: peter-evans/repository-dispatch@v3
             with:
-              token: ${{ secrets.CI_PAT }}
+              token: ${{ secrets.CALYPTIA_CI_PAT }}
               repository: chronosphereio/calyptia-frontend
               event-type: schema-update
             #   Some extra info if required

--- a/.github/workflows/update-go-fluentbit-config.yaml
+++ b/.github/workflows/update-go-fluentbit-config.yaml
@@ -17,7 +17,7 @@ jobs:
               with:
                   repository: chronosphereio/calyptia-go-fluentbit-config
                   path: go-fluentbit-config
-                  token: ${{ secrets.CI_PAT }}
+                  token: ${{ secrets.CALYPTIA_CI_PAT }}
 
             - name: Checkout to core-images-index repository.
               uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
               id: cpr
               uses: peter-evans/create-pull-request@v7
               with:
-                  token: ${{ secrets.CI_PAT }}
+                  token: ${{ secrets.CALYPTIA_CI_PAT }}
                   title: "Update schema to latest"
                   branch: "update-latest-schema"
                   delete-branch: true
@@ -63,4 +63,4 @@ jobs:
               run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
               working-directory: go-fluentbit-config
               env:
-                GH_TOKEN: ${{ secrets.CI_PAT }}
+                GH_TOKEN: ${{ secrets.CALYPTIA_CI_PAT }}


### PR DESCRIPTION
Depends on [this infra PR](https://github.com/chronosphereio/infrastructure/pull/11139) before merging. Rather than use repo-local CI secrets, instead use the shared `CALYPTIA_CI_PAT` secret.