### PR TITLE
ci: Upgrade GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/call-update-core-fluent-bit-schemas.yaml
+++ b/.github/workflows/call-update-core-fluent-bit-schemas.yaml
@@ -18,7 +18,7 @@
                 pr-url: ${{ steps.cpr.outputs.pull-request-url }}
             steps:
                 - name: Checkout core-images-index repo
-                  uses: actions/checkout@v4
+                  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
                   with:
                     token: ${{ secrets.token }}
                     repository: chronosphereio/calyptia-core-index
@@ -33,7 +33,7 @@
 
                 - name: Push to PR on index repo
                   id: cpr
-                  uses: peter-evans/create-pull-request@v7
+                  uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
                   with:
                     commit-message: 'ci: add core container images index'
                     signoff: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go-index/go.mod
 

--- a/.github/workflows/update-go-fluentbit-config.yaml
+++ b/.github/workflows/update-go-fluentbit-config.yaml
@@ -13,14 +13,14 @@ jobs:
             contents: read
         steps:
             - name: Checkout to go-fluentbit-config repository.
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: chronosphereio/calyptia-go-fluentbit-config
                   path: go-fluentbit-config
                   token: ${{ secrets.CALYPTIA_CI_PAT }}
 
             - name: Checkout to core-images-index repository.
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   path: core-images-index
 
@@ -32,7 +32,7 @@ jobs:
 
             - name: Create PR on go-fluentbit-config repository.
               id: cpr
-              uses: peter-evans/create-pull-request@v7
+              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
               with:
                   token: ${{ secrets.CALYPTIA_CI_PAT }}
                   title: "Update schema to latest"


### PR DESCRIPTION
## Summary
- Upgrades all JS-based GitHub Actions from Node 20 (or older) to Node 22+ versions
- SHA-pins all upgraded action references for supply-chain security
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

See also: [#587](https://github.com/chronosphereio/calyptia-core-index/pull/587) — upgrades Go from 1.18 to 1.26.3

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)