### PR TITLE
ci: Upgrade remaining GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Shellcheck
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ludeeus/action-shellcheck@master
 
   actionlint-pr:
     runs-on: ubuntu-latest
     name: PR - Actionlint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Markdownlint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Run markdownlint
         uses: actionshub/markdownlint@v3.1.4
 
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - GO lint
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go-index/go.mod
       - name: golangci-lint


### PR DESCRIPTION
## Summary
- Upgrades remaining JS-based GitHub Actions from Node 20 to Node 22+ versions (second wave)
- SHA-pins all upgraded action references for supply-chain security
- Covers docker/*, google-github-actions/*, aws-actions/*, azure/*, goreleaser/*, helm/kind-action, crazy-max/ghaction-import-gpg, and first-wave stragglers missed by a regex bug
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)